### PR TITLE
Empty and duplicate sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Javascript has one list type -- arrays, but DynamoDB has sets and lists. How doe
 
 Here's a table:
 
-| criteria              | input                 | marshaled value                                    |
+|                       | input                 | marshaled value                                    |
 | --------------------- | --------------------- | -------------------------------------------------- |
 | Strings/No duplicates | ["foo", "bar"]        | {"SS": ["foo", "bar"]}                             |
 | Numbers/No duplicates | [42, 43]              | {"NS": ["42", "43"]}                               |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ You can marshal directly from a JSON string. Or unmarshal a DynamoDb api respons
 
 More extensive examples can be found in the [examples](https://github.com/CascadeEnergy/dynamoDb-marshaler/tree/master/examples) directory.
 
+## Understanding the rules
+
+#### Empty strings
+DynamoDB does not allow saving of an empty string `""`. The marshaler treats this as an error.
+
+#### Sets vs Lists
+Javascript has one list type -- arrays, but DynamoDB has sets and lists. How does the marshaler distinguish between the two?
+
+Here's a table:
+
+| criteria              | input                 | marshaled value                                    |
+| --------------------- | --------------------- | -------------------------------------------------- |
+| Strings/No duplicates | ["foo", "bar"]        | {"SS": ["foo", "bar"]}                             |
+| Numbers/No duplicates | [42, 43]              | {"NS": ["42", "43"]}                               |
+| Empty                 | []                    | {"L": []}                                          |
+| Mixed                 | [42, "foo", null]     | {"L": [{"N": "42"}, {"S": "foo"}, {"NULL": true}]} |
+| Duplicates            | ["foo", "bar", "foo"] | {"L": [{"S": "foo"}, {"S": "bar"}, {"S": "foo"}]}  |
+
 ## Contributions
 
 Please contribute. But make sure test coverage is 100% and that the code

--- a/examples/example-marshal.js
+++ b/examples/example-marshal.js
@@ -22,7 +22,9 @@ var item = {
     }
   },
   favoriteFoods: ['burritos', 'fried chicken', 'pad kee mao'],
-  luckyNumbers: [42, 98, 777]
+  luckyNumbers: [42, 98, 777],
+  empty: [],
+  duplicateList: ['foo', 'bar', 'foo']
 };
 
 console.log(JSON.stringify(marshalItem(item)));
@@ -97,6 +99,22 @@ console.log(JSON.stringify(marshalItem(item)));
 //      "42",
 //      "98",
 //      "777"
+//    ]
+//  },
+//  "empty": {
+//    "L": []
+//  },
+//  "duplicateList": {
+//    "L": [
+//      {
+//        "S": "foo"
+//      },
+//      {
+//        "S": "bar"
+//      },
+//      {
+//        "S": "foo"
+//      }
 //    ]
 //  }
 //}

--- a/examples/example-unmarshal.js
+++ b/examples/example-unmarshal.js
@@ -39,6 +39,22 @@ var item = {
   },
   luckyNumbers: {
     NS: ['42', '98', '777']
+  },
+  empty: {
+    L: []
+  },
+  duplicateList: {
+    L: [
+      {
+        S: 'foo'
+      },
+      {
+        S: 'bar'
+      },
+      {
+        S: 'foo'
+      }
+    ]
   }
 };
 
@@ -66,5 +82,7 @@ console.log(unmarshalJson(item));
 //    }
 //  },
 //  "favoriteFoods": ["burritos", "fried chicken", "pad kee mao"],
-//  "luckyNumbers": [42, 98, 777]
+//  "luckyNumbers": [42, 98, 777],
+//  "empty": [],
+//  "duplicateList": ["foo", "bar", "foo"]
 //}

--- a/lib/commands/marshalNumberSet.js
+++ b/lib/commands/marshalNumberSet.js
@@ -3,15 +3,16 @@
 var _ = require('lodash');
 
 module.exports = function(item) {
-  if (!_.isArray(item)) {
+  if (
+    !_.isArray(item) ||
+    _.isEmpty(item) ||
+    !_.every(item, _.isNumber) ||
+    _.uniq(item).length !== item.length
+  ) {
     return undefined;
   }
 
-  if (!_.every(item, _.isNumber)) {
-    return undefined;
-  }
-
-  item = _.map(item, function(num) {
+  item = _.map(item, function stringify(num) {
     return num.toString();
   });
 

--- a/lib/commands/marshalStringSet.js
+++ b/lib/commands/marshalStringSet.js
@@ -3,11 +3,12 @@
 var _ = require('lodash');
 
 module.exports = function(item) {
-  if (!_.isArray(item)) {
-    return undefined;
-  }
-
-  if (!_.every(item, _.isString)) {
+  if (
+    !_.isArray(item) ||
+    _.isEmpty(item) ||
+    !_.every(item, _.isString) ||
+    _.uniq(item).length !== item.length
+  ) {
     return undefined;
   }
 

--- a/test/commands/marshalList.js
+++ b/test/commands/marshalList.js
@@ -1,15 +1,20 @@
 'use strict';
 
 var marshalList = require('../../lib/commands/marshalList');
+var sinon = require('sinon');
 var should = require('should');
-var marshal = function(item) {
-  return item + ' marshaled';
-};
 
 describe('marshalList', function() {
+  var marshal;
+
+  beforeEach(function() {
+    marshal = sinon.stub();
+  });
 
   it('should return undefined if item is not an Array', function() {
     var result = marshalList({}, marshal);
+
+    marshal.callCount.should.equal(0);
     (result === undefined).should.equal(true);
   });
 
@@ -17,10 +22,33 @@ describe('marshalList', function() {
     'should marshal each list item to the proper dynamoDb format',
     function() {
       var item = [42, 'foo', null];
-      var marshaledItem = ['42 marshaled', 'foo marshaled', 'null marshaled'];
-      var expected = {L: marshaledItem};
+      var result;
 
-      marshalList(item, marshal).should.eql(expected);
+      marshal.onFirstCall().returns('42 marshaled');
+      marshal.onSecondCall().returns('foo marshaled');
+      marshal.onThirdCall().returns('null marshaled');
+
+      result = marshalList(item, marshal);
+
+      marshal.calledThrice.should.equal(true);
+      should(marshal.args[0][0]).eql(42);
+      should(marshal.args[1][0]).eql('foo');
+      should(marshal.args[2][0]).eql(null);
+
+      result.should.eql({
+        L: [
+          '42 marshaled',
+          'foo marshaled',
+          'null marshaled'
+        ]
+      });
     }
   );
+
+  it('should marshal empty arrays to an empty list', function() {
+    var item = [];
+    var result = marshalList(item, marshal);
+    marshal.callCount.should.equal(0);
+    result.should.eql({L: []});
+  });
 });

--- a/test/commands/marshalNumberSet.js
+++ b/test/commands/marshalNumberSet.js
@@ -6,8 +6,10 @@ var withData = require('leche').withData;
 
 describe('marshalNumberSet', function() {
   withData({
-    'an item that is not an array': [{}],
-    'an array that is not all numbers': [[42, 'foo']]
+    'a non array': [{}],
+    'an empty array': [[]],
+    'an array that is not all numbers': [[42, 'foo']],
+    'an array with duplicates': [[42, 43, 42]]
   }, function(item) {
     it('should return undefined', function() {
       var result = marshalNumberSet(item);

--- a/test/commands/marshalStringSet.js
+++ b/test/commands/marshalStringSet.js
@@ -6,8 +6,10 @@ var withData = require('leche').withData;
 
 describe('marshalStringSet', function() {
   withData({
-    'an item that is not an array': [{}],
-    'an array that is not all strings': [[42, 'foo']]
+    'a non array': [{}],
+    'an empty array': [[]],
+    'an array that is not all strings': [[42, 'foo']],
+    'an array with duplicates': [['foo', 'bar', 'foo']]
   }, function(item) {
     it('should return undefined', function() {
       var result = marshalStringSet(item);

--- a/test/commands/unmarshalList.js
+++ b/test/commands/unmarshalList.js
@@ -1,21 +1,39 @@
 'use strict';
 
+var sinon = require('sinon');
+var should = require('should');
 var unmarshalList = require('../../lib/commands/unmarshalList');
-var unmarshal = function(item) {
-  return item + ' unmarshaled';
-};
 
 describe('unmarshalList', function() {
+  var unmarshal;
+
+  beforeEach(function() {
+    unmarshal = sinon.stub();
+  });
+
   it('should return undefined if the item does not have "L" key', function() {
     var result = unmarshalList({S: 'foo'}, unmarshal);
+    unmarshal.callCount.should.equal(0);
     (result === undefined).should.equal(true);
   });
 
   it(
     'should unmarshal the list, and unmarshal each value in the list',
     function() {
-      unmarshalList({L: ['FOOOBJ', 'BAROBJ']}, unmarshal)
-        .should
-        .eql(['FOOOBJ unmarshaled', 'BAROBJ unmarshaled']);
+      var result;
+
+      unmarshal.onFirstCall().returns('foo unmarshaled');
+      unmarshal.onSecondCall().returns('bar unmarshaled');
+
+      result = unmarshalList({L: ['foo', 'bar']}, unmarshal);
+
+      unmarshal.calledTwice.should.equal(true);
+      unmarshal.args[0][0].should.eql('foo');
+      unmarshal.args[1][0].should.eql('bar');
+
+      result.should.eql([
+        'foo unmarshaled',
+        'bar unmarshaled'
+      ]);
     });
 });


### PR DESCRIPTION
Fix, unit test coverage, and readme changes based on conversation with @psayre23 in PR #5 

**Summary of Changes**

|                       | input                 | marshaled value                                    |
| --------------------- | --------------------- | -------------------------------------------------- |
| Strings/No duplicates | ["foo", "bar"]        | {"SS": ["foo", "bar"]}                             |
| Numbers/No duplicates | [42, 43]              | {"NS": ["42", "43"]}                               |
| Empty                 | []                    | {"L": []}                                          |
| Mixed                 | [42, "foo", null]     | {"L": [{"N": "42"}, {"S": "foo"}, {"NULL": true}]} |
| Duplicates            | ["foo", "bar", "foo"] | {"L": [{"S": "foo"}, {"S": "bar"}, {"S": "foo"}]}  |

**To Test**

Verify unit test coverage is 100%: `gulp test`

Run example scripts and verify output.
```
node examples/example-marshal.js
node examples/example-unmarshal.js
```

Bonus points: Use the marshaler and actually save something to a database, and get it back out.