### PR TITLE
Added support for different cases of marshalled keys

### DIFF
--- a/lib/unmarshalingCommands.js
+++ b/lib/unmarshalingCommands.js
@@ -4,7 +4,7 @@ var _ = require('lodash/fp');
 var unexpectedItemHandler = require('./unexpectedItemHandler');
 var transform = require('./transform');
 
-/**
+**
  * Converts DynamoDb "L" to mixed array
  *
  * @param item
@@ -12,7 +12,18 @@ var transform = require('./transform');
  * @returns {*}
  */
 function unmarshalList(item, unmarshal) {
-  return transform(_.has('L'), _.compose(_.map(unmarshal), _.property('L')), item);
+  if (!_.has(item, 'L') && !_.has(item, 'l') ) {
+    return undefined;
+  }
+
+  if (_.has(item, 'L')) {
+    return _.map(item.L, unmarshal);
+  }
+
+  if (_.has(item, 'l')) {
+    return _.map(item.l, unmarshal);
+  }
+
 }
 
 /**
@@ -23,7 +34,17 @@ function unmarshalList(item, unmarshal) {
  * @returns {*}
  */
 function unmarshalMap(item, unmarshal) {
-  return transform(_.has('M'), _.compose(_.mapValues(unmarshal), _.property('M')), item);
+  if (!_.has(item, 'M') && !_.has(item, 'm')) {
+    return undefined;
+  }
+
+  if (_.has(item, 'M')) {
+    return _.mapValues(item.M, unmarshal);
+  }
+
+  if (_.has(item, 'm')) {
+    return _.mapValues(item.m, unmarshal);
+  }
 }
 
 /**
@@ -32,7 +53,13 @@ function unmarshalMap(item, unmarshal) {
  * @param item
  * @returns {*}
  */
-var unmarshalNull = transform(_.has('NULL'), _.constant(null));
+function unmarshalNull(item) {
+  if (!_.has(item, 'NULL') && !_.has(item, 'null')) {
+    return undefined;
+  }
+
+  return null;
+}
 
 /**
  * Converts DynamoDb "N" to Number
@@ -40,7 +67,19 @@ var unmarshalNull = transform(_.has('NULL'), _.constant(null));
  * @param item
  * @returns {*}
  */
-var unmarshalNumber = transform(_.has('N'), _.compose(parseFloat, _.property('N')));
+function unmarshalNumber(item) {
+  if (!_.has(item, 'N') && !_.has(item, 'n')) {
+    return undefined;
+  }
+
+  if (_.has(item, 'N')) {
+        return parseFloat(item.N);
+  }
+
+  if (_.has(item, 'n')) {
+    return parseFloat(item.n);
+  }
+}
 
 /**
  * Converts DynamoDb "NS" to Set of Numbers
@@ -48,7 +87,27 @@ var unmarshalNumber = transform(_.has('N'), _.compose(parseFloat, _.property('N'
  * @param item
  * @returns {*}
  */
-var unmarshalNumberSet = transform(_.has('NS'), _.compose(_.map(parseFloat), _.property('NS')));
+function unmarshalNumberSet(item) {
+  if (!_.has(item, 'NS') && !_.has(item, 'ns') && !_.has(item, 'Ns') && !_.has(item, 'nS') ) {
+    return undefined;
+  }
+
+  if (_.has(item, 'NS')) {
+   return _.map(item.NS, parseFloat);
+  }
+
+  if (_.has(item, 'ns')) {
+    return _.map(item.ns, parseFloat);
+  }
+
+  if (_.has(item, 'nS')) {
+    return _.map(item.nS, parseFloat);
+  }
+
+  if (_.has(item, 'Ns')) {
+    return _.map(item.Ns, parseFloat);
+  }
+}
 
 /**
  * Converts DynamoDb "SS" to Set of Strings
@@ -56,7 +115,27 @@ var unmarshalNumberSet = transform(_.has('NS'), _.compose(_.map(parseFloat), _.p
  * @param item
  * @returns {*}
  */
-var unmarshalStringSet = transform(_.has('SS'), _.property('SS'));
+function unmarshalStringSet(item) {
+  if (!_.has(item, 'SS') && !_.has(item, 'ss') && !_.has(item, 'sS') && !_.has(item, 'Ss')) {
+    return undefined;
+  }
+
+  if (_.has(item, 'SS')) {
+   return item.SS;
+  }
+
+  if (_.has(item, 'ss')) {
+    return item.ss;
+  }
+
+  if (_.has(item, 'Ss')) {
+    return item.Ss;
+  }
+
+  if (_.has(item, 'sS')) {
+    return item.sS;
+  }
+}
 
 /**
  * Converts DynamoDb "S", "B", "BS", "BOOL" to values.
@@ -64,13 +143,16 @@ var unmarshalStringSet = transform(_.has('SS'), _.property('SS'));
  * @param item
  * @returns {*}
  */
-
 function unmarshalPassThrough(item) {
-  var key = _.find(function(type) {
-    return _.has(type, item);
-  }, ['S', 'B', 'BS', 'BOOL']);
+  var key = _.find(['S', 'B', 'BS', 'BOOL','s','b','bs','bool','bOOL', 'boOl' , 'booL' ], function(type) {
+    return _.has(item, type);
+  });
 
-  return !key ? void 0 : item[key];
+  if (!key) {
+    return undefined;
+  }
+
+  return item[key];
 }
 
 module.exports = [

--- a/lib/unmarshalingCommands.js
+++ b/lib/unmarshalingCommands.js
@@ -4,7 +4,7 @@ var _ = require('lodash/fp');
 var unexpectedItemHandler = require('./unexpectedItemHandler');
 var transform = require('./transform');
 
-**
+/**
  * Converts DynamoDb "L" to mixed array
  *
  * @param item


### PR DESCRIPTION
AWS DataPipeline exports keys in a different case than AWS SDK for JS,
and this causes an issue when trying to unmarshall when you’ve got your
data in a different way than in the examples (using scans).

I've made my changes in the NPM version of the code and merged into the forked version from Git, please let me know if I've done anything wrong. (this is my first PR against a public repo!)