### PR TITLE
add keywords to search in npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
   },
   "author": "",
   "license": "MIT",
+  "keywords": [
+    "dynamodb",
+    "dynamodb-mashaler",
+    "dynamo",
+    "mashaler",
+    "parser"
+  ],
   "devDependencies": {
     "browserify": "^13.0.1",
     "istanbul": "^0.4.3",


### PR DESCRIPTION
I couldn't search this repository in npmjs.com. 
I've added keywords(dynamo, dynamodb, mashaler) in package.json.